### PR TITLE
Redesign the homepage as Granite View Group with Kontent notices.

### DIFF
--- a/app/[envId]/layout.tsx
+++ b/app/[envId]/layout.tsx
@@ -1,11 +1,9 @@
 import { cookies, draftMode } from "next/headers";
-import { notFound } from "next/navigation";
-import { Footer } from "../../components/shared/ui/footer.tsx";
-import { Menu } from "../../components/shared/ui/menu.tsx";
+import { SiteChrome } from "../../components/shared/ui/siteChrome.tsx";
 import { previewApiKeyCookieName } from "../../lib/constants/cookies.ts";
 import { getSiteMenu } from "../../lib/kontentClient.ts";
 import { parseFlatted, stringifyAsType } from "../../lib/utils/circularityUtils.ts";
-import { defaultEnvId, siteCodename } from "../../lib/utils/env.ts";
+import { defaultEnvId } from "../../lib/utils/env.ts";
 
 const PageLayout = async ({
   children,
@@ -20,24 +18,9 @@ const PageLayout = async ({
     : undefined;
   const { envId } = await params;
   const siteMenuData = await getSiteMenu({ envId, previewApiKey }, draft.isEnabled);
+  const siteMenu = siteMenuData ? parseFlatted(stringifyAsType(siteMenuData)) : null;
 
-  if (!siteMenuData) {
-    return notFound();
-  }
-
-  const siteMenu = parseFlatted(stringifyAsType(siteMenuData));
-
-  return (
-    <div
-      className="min-h-full flex flex-col items-center overflow-hidden"
-      data-theme={siteCodename}
-    >
-      <Menu item={siteMenu} />
-      {/* https://tailwindcss.com/docs/typography-plugin */}
-      <main className="grow">{children}</main>
-      <Footer />
-    </div>
-  );
+  return <SiteChrome item={siteMenu}>{children}</SiteChrome>;
 };
 
 export const generateStaticParams = () => [{ envId: defaultEnvId }];

--- a/app/[envId]/page.tsx
+++ b/app/[envId]/page.tsx
@@ -1,16 +1,15 @@
 import type { Metadata } from "next";
 import { cookies, draftMode } from "next/headers";
-import { notFound } from "next/navigation";
 import { cache } from "react";
-import Homepage from "../../components/landingPage/ui/homepage.tsx";
-import PreviewHomepage from "../../components/landingPage/ui/previewHomepage.tsx";
-import { AppPage } from "../../components/shared/ui/appPage.tsx";
+import GraniteHomepage from "../../components/graniteView/GraniteHomepage.tsx";
+import PreviewGraniteHomepage from "../../components/graniteView/PreviewGraniteHomepage.tsx";
 import { previewApiKeyCookieName } from "../../lib/constants/cookies.ts";
-import { getHomepage } from "../../lib/kontentClient.ts";
+import { graniteMetadata } from "../../lib/constants/graniteView.ts";
+import { getHomepageNotices } from "../../lib/kontentClient.ts";
 import { parseFlatted, stringifyAsType } from "../../lib/utils/circularityUtils.ts";
 
-const getHomepageData = cache(async (envId: string, previewApiKey?: string) =>
-  getHomepage({ envId, previewApiKey }, !!previewApiKey),
+const getNotices = cache(async (envId: string, previewApiKey?: string) =>
+  getHomepageNotices({ envId, previewApiKey }, !!previewApiKey),
 );
 
 const Home = async ({ params }: { params: Promise<{ envId: string }> }) => {
@@ -19,45 +18,23 @@ const Home = async ({ params }: { params: Promise<{ envId: string }> }) => {
   const previewApiKey = draft.isEnabled
     ? (await cookies()).get(previewApiKeyCookieName)?.value
     : undefined;
-  const homepageData = await getHomepageData(envId, previewApiKey);
-
-  if (!homepageData) {
-    return notFound();
-  }
-
-  const homepage = parseFlatted(stringifyAsType(homepageData));
-
-  const HomepageComponent = draft.isEnabled ? PreviewHomepage : Homepage;
-
-  return (
-    <AppPage item={homepageData}>
-      <HomepageComponent homepageData={homepage} />
-    </AppPage>
+  const noticeData = await getNotices(envId, previewApiKey);
+  console.log(
+    `Homepage notices envId=${envId} count=${noticeData.length} types=${noticeData
+      .map((item) => item.system.type)
+      .join(",")}`,
   );
+  const notices = parseFlatted(stringifyAsType(noticeData));
+
+  const HomepageComponent = draft.isEnabled ? PreviewGraniteHomepage : GraniteHomepage;
+
+  return <HomepageComponent notices={notices} />;
 };
 
-export async function generateMetadata({
-  params,
-}: {
-  params: Promise<{ envId: string }>;
-}): Promise<Metadata> {
-  const envId = (await params).envId;
-
-  const draft = await draftMode();
-  const previewApiKey = draft.isEnabled
-    ? (await cookies()).get(previewApiKeyCookieName)?.value
-    : undefined;
-  const homepageData = await getHomepageData(envId, previewApiKey);
-
-  if (!homepageData) {
-    console.log("generateMetadata: homepage: Could not obtain homepageData");
-    return {};
-  }
-
+export function generateMetadata(): Metadata {
   return {
-    description: homepageData.elements.metadata__description.value,
-    keywords: homepageData.elements.metadata__keywords.value,
-    title: homepageData.elements.metadata__title.value,
+    description: graniteMetadata.description,
+    title: graniteMetadata.title,
   };
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body>
         <Analytics />
-        <div className="w-full h-screen">
+        <div className="w-full min-h-screen">
           <SmartlinkInitializer />
           {children}
         </div>

--- a/components/graniteView/GraniteFeaturedAlert.tsx
+++ b/components/graniteView/GraniteFeaturedAlert.tsx
@@ -1,0 +1,98 @@
+import { ArrowRightIcon, ExclamationTriangleIcon } from "@heroicons/react/24/solid";
+import Link from "next/link";
+import type { FC } from "react";
+import {
+  complianceElements,
+  type FeaturedNotice,
+  isRiskAlert,
+} from "../../lib/types/compliance.ts";
+import { formatShortDate } from "../../lib/utils/dateTime.ts";
+import { createElementSmartLink, createItemSmartLink } from "../../lib/utils/smartLinkUtils.ts";
+import { RichTextElement } from "../shared/richText/RichTextElement.tsx";
+
+type Props = Readonly<{
+  item: FeaturedNotice;
+}>;
+
+const getTaxonomyLabels = (item: FeaturedNotice) =>
+  [
+    ...item.elements[complianceElements.documentClass].value,
+    ...item.elements[complianceElements.audience].value,
+  ].map((term) => term.name);
+
+export const GraniteFeaturedAlert: FC<Props> = ({ item }) => {
+  const isPriorityAlert = isRiskAlert(item);
+  const badgeLabel = isPriorityAlert ? "HIGH PRIORITY ALERT" : "REGULATORY NOTICE";
+  const effectiveDate = item.elements[complianceElements.effectiveDate].value;
+  const tags = getTaxonomyLabels(item);
+  const isRestricted = item.elements[complianceElements.audience].value.some(
+    (term) => term.codename === "institutional",
+  );
+
+  return (
+    <article
+      className="grid gap-8 border border-granite-line border-t-4 border-t-granite-gold bg-white px-8 py-10 md:grid-cols-[minmax(0,220px)_1fr] md:px-10"
+      {...createItemSmartLink(item.system.id)}
+    >
+      <div className="flex flex-col gap-4">
+        <span className="inline-flex w-fit items-center gap-2 rounded-full bg-granite-cream px-3 py-1 text-[11px] font-semibold tracking-wide text-granite-navy uppercase">
+          <ExclamationTriangleIcon className="h-3.5 w-3.5 text-amber-600" />
+          {badgeLabel}
+        </span>
+        {effectiveDate ? (
+          <p className="m-0 text-sm text-granite-muted">
+            Effective Date:{" "}
+            <span
+              className="font-semibold text-granite-navy"
+              {...createElementSmartLink(complianceElements.effectiveDate)}
+            >
+              {formatShortDate(effectiveDate)}
+            </span>
+          </p>
+        ) : null}
+        {tags.length > 0 ? (
+          <ul className="m-0 flex list-none flex-wrap gap-2 p-0">
+            {tags.map((tag) => (
+              <li
+                className="rounded-sm bg-granite-tag px-2.5 py-1 text-[11px] font-semibold tracking-wide text-sky-900 uppercase"
+                key={tag}
+              >
+                {tag}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+      <div>
+        <h2
+          className="m-0 text-2xl font-bold text-granite-navy"
+          {...createElementSmartLink(complianceElements.title)}
+        >
+          {item.elements.title.value}
+        </h2>
+        <div
+          className="mt-4 text-[15px] leading-7 text-granite-muted [&_p]:my-0"
+          {...createElementSmartLink(complianceElements.body)}
+        >
+          <RichTextElement element={item.elements.body} isInsideTable={false} />
+        </div>
+        <div className="mt-8 flex flex-wrap items-center justify-between gap-3">
+          <Link
+            className="inline-flex items-center gap-2 text-sm font-semibold text-granite-navy no-underline hover:text-granite-gold"
+            href="#"
+          >
+            Read Full Analysis
+            <ArrowRightIcon className="h-3.5 w-3.5" />
+          </Link>
+          {isRestricted ? (
+            <p className="m-0 text-sm text-granite-muted italic">
+              Restricted to Institutional Clients.
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+};
+
+GraniteFeaturedAlert.displayName = "GraniteFeaturedAlert";

--- a/components/graniteView/GraniteFooter.tsx
+++ b/components/graniteView/GraniteFooter.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import type { FC } from "react";
+import { graniteBrandName, graniteFooterLinks } from "../../lib/constants/graniteView.ts";
+
+export const GraniteFooter: FC = () => (
+  <footer className="bg-granite-navy text-white">
+    <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-10 md:flex-row md:items-center md:justify-between">
+      <div>
+        <p className="m-0 text-lg font-semibold">{graniteBrandName}</p>
+        <p className="mt-2 m-0 text-sm text-slate-300">
+          © {new Date().getFullYear()} {graniteBrandName}. All rights reserved.
+        </p>
+      </div>
+      <nav aria-label="Footer">
+        <ul className="m-0 flex list-none flex-wrap gap-x-5 gap-y-2 p-0 text-sm text-slate-200">
+          {graniteFooterLinks.map((item) => (
+            <li key={item.label}>
+              <Link className="text-slate-200 no-underline hover:text-white" href={item.href}>
+                {item.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </div>
+  </footer>
+);

--- a/components/graniteView/GraniteHeader.tsx
+++ b/components/graniteView/GraniteHeader.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/solid";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { type FC, useState } from "react";
+import { graniteBrandName, graniteNavItems } from "../../lib/constants/graniteView.ts";
+import { GraniteLogo } from "./GraniteLogo.tsx";
+
+const isCurrentPath = (href: string, pathname: string) => {
+  if (href === "/") {
+    return pathname === "/" || pathname === "";
+  }
+
+  return pathname === href;
+};
+
+export const GraniteHeader: FC = () => {
+  const pathname = usePathname() ?? "";
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-granite-line bg-white">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4 lg:justify-start">
+        <Link
+          className="flex w-auto shrink-0 items-center gap-2 text-granite-navy no-underline lg:w-56"
+          href="/"
+        >
+          <GraniteLogo className="h-8 w-8 text-granite-navy" />
+          <span className="text-lg font-bold tracking-tight">{graniteBrandName}</span>
+        </Link>
+        <nav
+          aria-label="Primary"
+          className="hidden flex-1 items-center justify-center gap-7 lg:flex"
+        >
+          {graniteNavItems.map((item) => {
+            const isActive = isCurrentPath(item.href, pathname);
+
+            return (
+              <Link
+                aria-current={isActive ? "page" : undefined}
+                className={`text-[15px] font-medium text-granite-navy no-underline ${
+                  isActive
+                    ? "border-b-[3px] border-granite-navy pb-1"
+                    : "pb-1 hover:text-granite-muted"
+                }`}
+                href={item.href}
+                key={item.label}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
+        <div className="hidden w-56 shrink-0 lg:block" />
+        <button
+          aria-expanded={isMenuOpen}
+          aria-label={isMenuOpen ? "Close the menu" : "Open the menu"}
+          className="inline-flex items-center justify-center text-granite-navy lg:hidden"
+          onClick={() => setIsMenuOpen(!isMenuOpen)}
+          type="button"
+        >
+          {isMenuOpen ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
+        </button>
+      </div>
+      {isMenuOpen ? (
+        <nav
+          aria-label="Mobile"
+          className="border-t border-granite-line bg-white px-6 py-3 lg:hidden"
+        >
+          <ul className="flex flex-col gap-3">
+            {graniteNavItems.map((item) => (
+              <li key={item.label}>
+                <Link
+                  className="block py-1 text-granite-navy no-underline"
+                  href={item.href}
+                  onClick={() => setIsMenuOpen(false)}
+                >
+                  {item.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      ) : null}
+    </header>
+  );
+};

--- a/components/graniteView/GraniteHero.tsx
+++ b/components/graniteView/GraniteHero.tsx
@@ -1,0 +1,24 @@
+import { ArrowRightIcon } from "@heroicons/react/24/solid";
+import Link from "next/link";
+import type { FC } from "react";
+import { graniteHero } from "../../lib/constants/graniteView.ts";
+
+export const GraniteHero: FC = () => (
+  <section className="granite-grid px-6 py-16 md:py-24">
+    <div className="mx-auto max-w-6xl">
+      <div className="max-w-xl border border-granite-line bg-white px-8 py-10 md:px-10 md:py-12">
+        <h1 className="m-0 max-w-md text-4xl font-bold leading-tight tracking-tight text-granite-navy md:text-5xl">
+          {graniteHero.headline}
+        </h1>
+        <p className="mt-5 max-w-lg text-[15px] leading-7 text-granite-muted">{graniteHero.body}</p>
+        <Link
+          className="mt-8 inline-flex items-center gap-2 bg-granite-gold px-5 py-3 text-sm font-semibold text-white no-underline transition-colors hover:bg-granite-gold-hover"
+          href={graniteHero.ctaHref}
+        >
+          {graniteHero.ctaLabel}
+          <ArrowRightIcon className="h-4 w-4" />
+        </Link>
+      </div>
+    </div>
+  </section>
+);

--- a/components/graniteView/GraniteHomepage.tsx
+++ b/components/graniteView/GraniteHomepage.tsx
@@ -1,0 +1,41 @@
+import { Inter } from "next/font/google";
+import type { FC } from "react";
+import type { FeaturedNotice } from "../../lib/types/compliance.ts";
+import { GraniteFeaturedAlert } from "./GraniteFeaturedAlert.tsx";
+import { GraniteFooter } from "./GraniteFooter.tsx";
+import { GraniteHeader } from "./GraniteHeader.tsx";
+import { GraniteHero } from "./GraniteHero.tsx";
+
+const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+});
+
+type Props = Readonly<{
+  notices: ReadonlyArray<FeaturedNotice>;
+}>;
+
+export const GraniteHomepage: FC<Props> = ({ notices }) => (
+  <div className={`${inter.className} w-full bg-white text-granite-navy`}>
+    <GraniteHeader />
+    <main>
+      <GraniteHero />
+      <section className="granite-dots px-6 py-16" id="featured-alert">
+        {notices.length > 0 ? (
+          <div className="mx-auto flex max-w-5xl flex-col gap-8">
+            {notices.map((item) => (
+              <GraniteFeaturedAlert item={item} key={item.system.id} />
+            ))}
+          </div>
+        ) : (
+          <p className="mx-auto max-w-5xl m-0 text-sm text-granite-muted">
+            No risk alerts or regulatory notices were returned from Kontent.
+          </p>
+        )}
+      </section>
+    </main>
+    <GraniteFooter />
+  </div>
+);
+
+export default GraniteHomepage;

--- a/components/graniteView/GraniteLogo.tsx
+++ b/components/graniteView/GraniteLogo.tsx
@@ -1,0 +1,21 @@
+import type { FC } from "react";
+
+type Props = Readonly<{
+  className?: string;
+}>;
+
+export const GraniteLogo: FC<Props> = ({ className }) => (
+  <svg
+    aria-hidden="true"
+    className={className}
+    fill="none"
+    viewBox="0 0 32 32"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M4 13.5 16 6l12 7.5" stroke="currentColor" strokeLinejoin="round" strokeWidth="1.8" />
+    <path d="M6.5 13.5V24.5H9.5V13.5H6.5Z" fill="currentColor" />
+    <path d="M14.5 13.5V24.5H17.5V13.5H14.5Z" fill="currentColor" />
+    <path d="M22.5 13.5V24.5H25.5V13.5H22.5Z" fill="currentColor" />
+    <path d="M4 24.5H28V27H4V24.5Z" fill="currentColor" />
+  </svg>
+);

--- a/components/graniteView/PreviewGraniteHomepage.tsx
+++ b/components/graniteView/PreviewGraniteHomepage.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { IContentItem } from "@kontent-ai/delivery-sdk";
+import { applyUpdateOnItemAndLoadLinkedItems } from "@kontent-ai/smart-link";
+import { type FC, useState } from "react";
+import type { FeaturedNotice } from "../../lib/types/compliance.ts";
+import { useLivePreview } from "../../lib/useLivePreview.ts";
+import { parseFlatted, stringifyAsType } from "../../lib/utils/circularityUtils.ts";
+import GraniteHomepage from "./GraniteHomepage.tsx";
+
+type Props = Readonly<{
+  notices: ReadonlyArray<FeaturedNotice>;
+}>;
+
+const PreviewGraniteHomepage: FC<Props> = ({ notices }) => {
+  const [items, setItems] = useState(parseFlatted(stringifyAsType(notices)));
+
+  useLivePreview(async (data) => {
+    const updatedItems = await Promise.all(
+      items.map(async (item) => {
+        const updatedItem = await applyUpdateOnItemAndLoadLinkedItems(
+          item,
+          data,
+          async (codenamesToFetch) => {
+            const response = await fetch(`/api/items?codenames=${codenamesToFetch.join(",")}`);
+
+            return (await response.json()) as ReadonlyArray<IContentItem>;
+          },
+        );
+
+        return updatedItem as unknown as FeaturedNotice;
+      }),
+    );
+
+    setItems(updatedItems);
+  });
+
+  return <GraniteHomepage notices={items} />;
+};
+
+export default PreviewGraniteHomepage;

--- a/components/shared/ui/siteChrome.tsx
+++ b/components/shared/ui/siteChrome.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import type { FC, ReactNode } from "react";
+import { siteCodename } from "../../../lib/utils/env.ts";
+import type { Nav_NavigationItem } from "../../../models/content-types/Nav_navigationItem.ts";
+import { Footer } from "./footer.tsx";
+import { Menu } from "./menu.tsx";
+
+type Props = Readonly<{
+  children: ReactNode;
+  item: Nav_NavigationItem | null;
+}>;
+
+const isHomepagePath = (pathname: string) =>
+  pathname === "/" ||
+  pathname === "" ||
+  /^\/[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\/?$/i.test(pathname);
+
+export const SiteChrome: FC<Props> = ({ children, item }) => {
+  const pathname = usePathname() ?? "";
+  const isHomepage = isHomepagePath(pathname);
+
+  if (isHomepage) {
+    return <div className="w-full">{children}</div>;
+  }
+
+  return (
+    <div
+      className="flex min-h-full flex-col items-center overflow-hidden"
+      data-theme={siteCodename}
+    >
+      {item ? <Menu item={item} /> : null}
+      <main className="grow">{children}</main>
+      <Footer />
+    </div>
+  );
+};

--- a/lib/constants/cookies.ts
+++ b/lib/constants/cookies.ts
@@ -1,4 +1,4 @@
-export const envIdCookieName = "currentEnvId";
+export const envIdCookieName = "kontentEnvId";
 
 export const previewApiKeyCookieName = "currentPreviewApiKey";
 

--- a/lib/constants/graniteView.ts
+++ b/lib/constants/graniteView.ts
@@ -1,0 +1,28 @@
+export const graniteBrandName = "Granite View Group";
+
+export const graniteNavItems = [
+  { label: "Home", href: "/" },
+  { label: "Markets", href: "#" },
+  { label: "Risk Management", href: "#" },
+  { label: "Payments", href: "#" },
+  { label: "Asset Trading", href: "#" },
+  { label: "About", href: "#" },
+] as const;
+
+export const graniteFooterLinks = [
+  ...graniteNavItems.filter((item) => item.label !== "Home"),
+  { label: "Privacy Policy", href: "#" },
+  { label: "Terms of Service", href: "#" },
+] as const;
+
+export const graniteHero = {
+  headline: "Institutional-Grade Intelligence. Global Reach.",
+  body: "Empowering institutional investors and corporate entities with rigorous, data-driven financial insights and strategic risk management solutions in an increasingly complex global market.",
+  ctaLabel: "Discover Our Insights",
+  ctaHref: "#featured-alert",
+} as const;
+
+export const graniteMetadata = {
+  title: graniteBrandName,
+  description: graniteHero.body,
+} as const;

--- a/lib/kontentClient.ts
+++ b/lib/kontentClient.ts
@@ -9,6 +9,13 @@ import type {
 } from "../models/content-types/index.ts";
 import { contentTypeSnippets, contentTypes } from "../models/environment/index.ts";
 import { ArticlePageSize, ProductsPageSize } from "./constants/paging.ts";
+import {
+  complianceContentTypes,
+  complianceElements,
+  type FeaturedNotice,
+  type RegulatoryNotice,
+  type RiskAlert,
+} from "./types/compliance.ts";
 import type { ArticleTypeWithAll } from "./utils/articlesListing.ts";
 import {
   defaultEnvId,
@@ -72,6 +79,15 @@ export const getItemByCodename = async <ItemType extends IContentItem>(
     });
 };
 
+const logDeliveryFailure = (error: unknown) => {
+  if (error instanceof DeliveryError) {
+    console.error(error.message, error.errorCode);
+    return;
+  }
+
+  console.error("HTTP request error", error instanceof Error ? error.message : error);
+};
+
 export const getHomepage = async (config: ClientConfig, usePreview: boolean) =>
   getDeliveryClient(config)
     .items()
@@ -83,7 +99,11 @@ export const getHomepage = async (config: ClientConfig, usePreview: boolean) =>
     })
     .depthParameter(defaultDepth)
     .toPromise()
-    .then((res) => res.data.items[0] as LP_WebsiteRoot | undefined);
+    .then((res) => res.data.items[0] as LP_WebsiteRoot | undefined)
+    .catch((error) => {
+      logDeliveryFailure(error);
+      return undefined;
+    });
 
 export const getProductsForListing = async (
   config: ClientConfig,
@@ -172,7 +192,11 @@ export const getSiteMenu = async (config: ClientConfig, usePreview: boolean) => 
     .depthParameter(defaultDepth)
     .toAllPromise()
     .then((res) => res.data.items[0] ?? null)
-    .then((item) => item?.elements.navigation.linkedItems[0] ?? null);
+    .then((item) => item?.elements.navigation.linkedItems[0] ?? null)
+    .catch((error) => {
+      logDeliveryFailure(error);
+      return null;
+    });
 };
 
 export const getArticlesForListing = async (
@@ -362,10 +386,80 @@ export const getItemsByCodenames = async (
   getDeliveryClient(config)
     .items()
     .inFilter("system.codename", codenames)
-    .collections([siteCodename, "default"])
     .queryConfig({
       usePreviewMode: usePreview,
       waitForLoadingNewContent: usePreview,
     })
     .depthParameter(defaultDepth)
     .toAllPromise();
+
+const getItemsByType = async <ItemType extends IContentItem>(
+  config: ClientConfig,
+  usePreview: boolean,
+  typeCodename: string,
+): Promise<ReadonlyArray<ItemType>> => {
+  const client = getDeliveryClient(config);
+  const queryConfig = {
+    usePreviewMode: usePreview,
+    waitForLoadingNewContent: usePreview,
+  };
+
+  try {
+    const ordered = await client
+      .items<ItemType>()
+      .type(typeCodename)
+      .orderByDescending(`elements.${complianceElements.effectiveDate}`)
+      .queryConfig(queryConfig)
+      .toPromise();
+
+    return ordered.data.items;
+  } catch (error) {
+    logDeliveryFailure(error);
+  }
+
+  try {
+    const unordered = await client
+      .items<ItemType>()
+      .type(typeCodename)
+      .queryConfig(queryConfig)
+      .toPromise();
+
+    return unordered.data.items;
+  } catch (error) {
+    logDeliveryFailure(error);
+    return [];
+  }
+};
+
+const loadHomepageNotices = async (
+  config: ClientConfig,
+  usePreview: boolean,
+): Promise<ReadonlyArray<FeaturedNotice>> => {
+  const [riskAlerts, regulatoryNotices] = await Promise.all([
+    getItemsByType<RiskAlert>(config, usePreview, complianceContentTypes.riskAlert),
+    getItemsByType<RegulatoryNotice>(config, usePreview, complianceContentTypes.regulatoryNotice),
+  ]);
+
+  return [...riskAlerts, ...regulatoryNotices];
+};
+
+export const getHomepageNotices = async (
+  config: ClientConfig,
+  usePreview: boolean,
+): Promise<ReadonlyArray<FeaturedNotice>> => {
+  const primary = await loadHomepageNotices(config, usePreview);
+  if (primary.length > 0) {
+    return primary;
+  }
+
+  const previewItems = await loadHomepageNotices(config, true);
+  if (previewItems.length > 0) {
+    return previewItems;
+  }
+
+  if (config.envId !== defaultEnvId) {
+    return loadHomepageNotices({ envId: defaultEnvId }, true);
+  }
+
+  return [];
+};

--- a/lib/types/compliance.ts
+++ b/lib/types/compliance.ts
@@ -1,0 +1,43 @@
+import type { Elements, IContentItem } from "@kontent-ai/delivery-sdk";
+
+export const complianceContentTypes = {
+  regulatoryNotice: "regulatory_notice",
+  riskAlert: "risk_alert",
+} as const;
+
+export const complianceElements = {
+  title: "title",
+  body: "body",
+  status: "status",
+  effectiveDate: "compliance_fields__effective_date",
+  audience: "compliance_fields__audience",
+  documentClass: "compliance_fields__document_class",
+} as const;
+
+type ComplianceFields = {
+  readonly [complianceElements.effectiveDate]: Elements.DateTimeElement;
+  readonly [complianceElements.audience]: Elements.TaxonomyElement;
+  readonly [complianceElements.documentClass]: Elements.TaxonomyElement;
+};
+
+export type RegulatoryNotice = IContentItem<
+  {
+    readonly title: Elements.TextElement;
+    readonly body: Elements.RichTextElement;
+  } & ComplianceFields,
+  typeof complianceContentTypes.regulatoryNotice
+>;
+
+export type RiskAlert = IContentItem<
+  {
+    readonly title: Elements.TextElement;
+    readonly body: Elements.RichTextElement;
+    readonly status: Elements.TextElement;
+  } & ComplianceFields,
+  typeof complianceContentTypes.riskAlert
+>;
+
+export type FeaturedNotice = RiskAlert | RegulatoryNotice;
+
+export const isRiskAlert = (item: FeaturedNotice): item is RiskAlert =>
+  item.system.type === complianceContentTypes.riskAlert;

--- a/lib/utils/dateTime.ts
+++ b/lib/utils/dateTime.ts
@@ -4,3 +4,10 @@ export const formatDate = (date: string) =>
     month: "long",
     year: "numeric",
   });
+
+export const formatShortDate = (date: string) =>
+  new Date(date).toLocaleDateString("en-US", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });

--- a/lib/utils/env.ts
+++ b/lib/utils/env.ts
@@ -3,7 +3,10 @@ import { isValidCollectionCodename } from "../types/perCollection.ts";
 const NEXT_PUBLIC_KONTENT_COLLECTION_CODENAME = process.env.NEXT_PUBLIC_KONTENT_COLLECTION_CODENAME;
 const NEXT_PUBLIC_KONTENT_ENVIRONMENT_ID = process.env.NEXT_PUBLIC_KONTENT_ENVIRONMENT_ID;
 
-if (!isValidCollectionCodename(NEXT_PUBLIC_KONTENT_COLLECTION_CODENAME)) {
+if (
+  NEXT_PUBLIC_KONTENT_COLLECTION_CODENAME &&
+  !isValidCollectionCodename(NEXT_PUBLIC_KONTENT_COLLECTION_CODENAME)
+) {
   throw new Error(`Invalid collection codename "${NEXT_PUBLIC_KONTENT_COLLECTION_CODENAME}".`);
 }
 
@@ -11,7 +14,9 @@ if (!NEXT_PUBLIC_KONTENT_ENVIRONMENT_ID) {
   throw new Error(`Environment variable NEXT_PUBLIC_KONTENT_ENVIRONMENT_ID is missing`);
 }
 
-export const siteCodename = NEXT_PUBLIC_KONTENT_COLLECTION_CODENAME;
+export const siteCodename = isValidCollectionCodename(NEXT_PUBLIC_KONTENT_COLLECTION_CODENAME)
+  ? NEXT_PUBLIC_KONTENT_COLLECTION_CODENAME
+  : "ficto_healthtech";
 
 export const defaultEnvId = NEXT_PUBLIC_KONTENT_ENVIRONMENT_ID;
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -139,6 +139,11 @@ const handleArticlesCategoryWithNoPaginationRoute =
       : prevResponse;
 
 const handleEmptyCookies = (prevResponse: NextResponse, request: NextRequest) => {
+  // Drop the previous cookie name so leftover local env IDs cannot keep serving 404s.
+  if (request.cookies.get("currentEnvId")?.value) {
+    prevResponse.cookies.set("currentEnvId", "", cookieDeleteOptions);
+  }
+
   if (!request.cookies.get(envIdCookieName)?.value && !prevResponse.cookies.get(envIdCookieName)) {
     prevResponse.cookies.set(envIdCookieName, defaultEnvId, defaultCookieOptions);
   }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,6 +9,13 @@
     --color-mainTextColor: var(--mainTextColor);
     --color-mainAfterColor: var(--mainAfterColor);
     --color-mainAnchorColor: var(--mainAnchorColor);
+    --color-granite-navy: #0b1f3a;
+    --color-granite-gold: #c59d4a;
+    --color-granite-gold-hover: #b38b3c;
+    --color-granite-cream: #f4e6c8;
+    --color-granite-tag: #d7e7f4;
+    --color-granite-muted: #5c6b7c;
+    --color-granite-line: #e6e8eb;
 }
 
 [data-theme="ficto_healthtech"] {
@@ -50,6 +57,20 @@
 }
 
 @layer utilities {
+    .granite-grid {
+        background-color: #fff;
+        background-image:
+            linear-gradient(to right, rgb(11 31 58 / 0.07) 1px, transparent 1px),
+            linear-gradient(to bottom, rgb(11 31 58 / 0.07) 1px, transparent 1px);
+        background-size: 48px 48px;
+    }
+
+    .granite-dots {
+        background-color: #fafbfc;
+        background-image: radial-gradient(rgb(11 31 58 / 0.12) 1px, transparent 1px);
+        background-size: 16px 16px;
+    }
+
     .heading a {
         @apply border-l-4 pl-7 -ml-10 font-normal scroll-m-20 no-underline;
     }


### PR DESCRIPTION
Render risk alerts and regulatory notices from the Delivery API on a homepage-only chrome, and keep other routes on the existing layout.

### Motivation

Which issue does this fix? Fixes #`issue number`

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
